### PR TITLE
Fix logrotate problem with twice configured pid-file option

### DIFF
--- a/debian/mariadb-server-10.4.mysql-server.logrotate
+++ b/debian/mariadb-server-10.4.mysql-server.logrotate
@@ -11,7 +11,7 @@
 	sharedscripts
 	postrotate
           test -x /usr/bin/mysqladmin || exit 0
-          if [ -f `my_print_defaults --mysqld | grep -oP "pid-file=\K[^$]+"` ]; then
+          if [ -f `my_print_defaults --mysqld | grep -m 1 -oP "pid-file=\K.+$"` ]; then
             # If this fails, check debian.conf!
             mysqladmin --defaults-file=/etc/mysql/debian.cnf --local flush-error-log \
               flush-engine-log flush-general-log flush-slow-log


### PR DESCRIPTION
Hi,

if the pid-file option is configured more than once (e.g. multiple times in different files), my_print_defaults prints it twice, resulting in the logrotate postrotate script failing because of a syntax error. Debian fixed this already (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=830976#42).

Perhaps you could implement this small change in the other branches as well?

Thanks,

Christopher